### PR TITLE
Redifined detection function for supported Browser and OS

### DIFF
--- a/src/views/blockly.html.twig
+++ b/src/views/blockly.html.twig
@@ -200,6 +200,9 @@
      * Document Ready actions
      */
     $(document).ready(function(){
+        window.osBrowserIsSupported = function () {
+            return true;
+        };
         compilerflasher = new compilerflasher(getFiles);
 
         /**


### PR DESCRIPTION
Because compilerflasher runs under a codebender.cc domain (blockly.codebeder.cc), it expects that the function that detects for supported Browser and OS to be defined.

In this branch the above function is redefined in order to allow compilerflasher to initialize correctly.
